### PR TITLE
Remove gpg from brew install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,7 +33,6 @@ brew install \
   awscli \
   fzf \
   go \
-  gpg \
   imagemagick \
   jq \
   kubectl \


### PR DESCRIPTION
We'll use gpgtools.org instead.